### PR TITLE
fix compilation with gcc6

### DIFF
--- a/include/linux/compiler-gcc.h
+++ b/include/linux/compiler-gcc.h
@@ -103,7 +103,11 @@
 #define __gcc_header(x) #x
 #define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
 #define gcc_header(x) _gcc_header(x)
+#if (__GNUC__ > 5)
+#include gcc_header(5)
+#else
 #include gcc_header(__GNUC__)
+#endif
 
 #if !defined(__noclone)
 #define __noclone	/* not needed */


### PR DESCRIPTION
Fixes: linux/compiler-gcc6.h: No such file or directory

Via macros the build will try to include a gcc version-specific header
file, but this doesn't exist for gcc6, so use gcc5's header file for
gcc6+.  Tested with gcc6, didn't test with gcc7.

Signed-off-by: Nicholas Sielicki <sielicki@yandex.com>